### PR TITLE
XCode 10.2 fix for matching iOS simulators

### DIFF
--- a/local-cli/runIOS/findMatchingSimulator.js
+++ b/local-cli/runIOS/findMatchingSimulator.js
@@ -25,7 +25,7 @@ function findMatchingSimulator(simulators, simulatorName) {
   var match;
   for (let version in devices) {
     // Making sure the version of the simulator is an iOS or tvOS (Removes Apple Watch, etc)
-    if (!version.startsWith('iOS') && !version.startsWith('tvOS')) {
+    if (!version.startsWith('com.apple.CoreSimulator.SimRuntime.iOS') && !version.startsWith('com.apple.CoreSimulator.SimRuntime.tvOS')) {
       continue;
     }
     for (let i in devices[version]) {


### PR DESCRIPTION
Since XCode 10.2 finding a match of simulators has been changed and a small tweak is necessary to be made on the old branch (version) of RN we're using (0.55.3-npm)